### PR TITLE
[Chore] Add bottle hashes for v20.2-rc1

### DIFF
--- a/Formula/mavryk-accuser-PtBoreas.rb
+++ b/Formula/mavryk-accuser-PtBoreas.rb
@@ -26,6 +26,7 @@ class MavrykAccuserPtboreas < Formula
 
   bottle do
     root_url "https://github.com/mavryk-network/mavryk-packaging/releases/download/#{MavrykAccuserPtboreas.version}/"
+    sha256 cellar: :any, arm64_sonoma: "398df556f585af37917d5a581f0b234f46128eea153ccb479d52c17a752f0da0"
     sha256 cellar: :any, arm64_sonoma: "bcb600337a732b62f3c4a231360135b4f7eab0666e6ab3423b36a46f799d524d"
     sha256 cellar: :any, monterey: "7b614c2748b4e74c7445f2885e5038521a0ba7730b2edab8f8e657eab5ceaac1"
   end

--- a/Formula/mavryk-admin-client.rb
+++ b/Formula/mavryk-admin-client.rb
@@ -26,6 +26,7 @@ class MavrykAdminClient < Formula
 
   bottle do
     root_url "https://github.com/mavryk-network/mavryk-packaging/releases/download/#{MavrykAdminClient.version}/"
+    sha256 cellar: :any, arm64_sonoma: "953bb3055a0a68a1c83906ef907f4c629c3dc7782b7979392f94b9233a300209"
     sha256 cellar: :any, arm64_sonoma: "8da788eeb036f332aecc87a24582af97754ff5cc4d25609b6746d45e84f801c8"
     sha256 cellar: :any, monterey: "9edd116e2876599bfae40898e5f3d178a73446e26a7dc519529058b6a63e422a"
   end

--- a/Formula/mavryk-baker-PtBoreas.rb
+++ b/Formula/mavryk-baker-PtBoreas.rb
@@ -26,6 +26,7 @@ class MavrykBakerPtboreas < Formula
 
   bottle do
     root_url "https://github.com/mavryk-network/mavryk-packaging/releases/download/#{MavrykBakerPtboreas.version}/"
+    sha256 cellar: :any, arm64_sonoma: "43a74d065578e1ce94b1639a77246e5413a29a4ffbad5b8417bdc1ce044ae664"
     sha256 cellar: :any, arm64_sonoma: "87a3ae5d67d71bff01445060216d7d56e8ae0288440d30ebaceb38d982864c49"
     sha256 cellar: :any, monterey: "88983b11846d56d8087d600905b568511215a0653beaa2769adebe5aa79ad894"
   end

--- a/Formula/mavryk-client.rb
+++ b/Formula/mavryk-client.rb
@@ -26,6 +26,7 @@ class MavrykClient < Formula
 
   bottle do
     root_url "https://github.com/mavryk-network/mavryk-packaging/releases/download/#{MavrykClient.version}/"
+    sha256 cellar: :any, arm64_sonoma: "efaca11b35bb5c47a9e0b098915b7d3c32867a6edac85a05463bc91d345bffb0"
     sha256 cellar: :any, arm64_sonoma: "3a9866cf9fbdca8c0516b171f8b56cf8815d3bf02eab72e2cf4b9666ffd61361"
     sha256 cellar: :any, monterey: "369247c4fb2a2458f56354023027e670d11cfb5b848486781c0e590242d86a83"
   end

--- a/Formula/mavryk-codec.rb
+++ b/Formula/mavryk-codec.rb
@@ -26,6 +26,7 @@ class MavrykCodec < Formula
 
   bottle do
     root_url "https://github.com/mavryk-network/mavryk-packaging/releases/download/#{MavrykCodec.version}/"
+    sha256 cellar: :any, arm64_sonoma: "08ffc6739de6cf8323145aef93c984e24f2b5c83d046fd5ad2823c5ff7c3ea8e"
     sha256 cellar: :any, arm64_sonoma: "69789ec51c494f878bb4051dcc74d0d5eb2c8f50adb4a62209b98c013d574d72"
     sha256 cellar: :any, monterey: "3323a7f425b05a83ec34e96cea95cfb1f68d21d23dd3d9dbb6878b72dbacc718"
   end

--- a/Formula/mavryk-dac-node.rb
+++ b/Formula/mavryk-dac-node.rb
@@ -26,6 +26,7 @@ class MavrykDacNode < Formula
 
   bottle do
     root_url "https://github.com/mavryk-network/mavryk-packaging/releases/download/#{MavrykDacNode.version}/"
+    sha256 cellar: :any, arm64_sonoma: "80c7191ace6db317198af4c3bf3988e2de9513031ded6aa40c7fe113b217cc28"
     sha256 cellar: :any, arm64_sonoma: "86b29459d44d39fbc864697184f560ce518bb56a50ec2205743c12ba081fd881"
     sha256 cellar: :any, monterey: "b97e0b4e24fd12b83f2caf66ce20807b3f957ac9249377dc3d90ce2d047b2e78"
   end

--- a/Formula/mavryk-dal-node.rb
+++ b/Formula/mavryk-dal-node.rb
@@ -26,6 +26,7 @@ class MavrykDalNode < Formula
 
   bottle do
     root_url "https://github.com/mavryk-network/mavryk-packaging/releases/download/#{MavrykDalNode.version}/"
+    sha256 cellar: :any, arm64_sonoma: "c4916b1430d7c512a22eaad976a31313f399e79466342faaf0e3b3438f115441"
     sha256 cellar: :any, arm64_sonoma: "7e9c96d6a2ae7ba7f7c61da1ac62f6b8331e8198b79ca16594fe6614afc311bf"
     sha256 cellar: :any, monterey: "07d1ea35af52627449bfa7f7f1ccf49bd0bbbe7e90e01c4dc24af40588100196"
   end

--- a/Formula/mavryk-node.rb
+++ b/Formula/mavryk-node.rb
@@ -26,6 +26,7 @@ class MavrykNode < Formula
 
   bottle do
     root_url "https://github.com/mavryk-network/mavryk-packaging/releases/download/#{MavrykNode.version}/"
+    sha256 cellar: :any, arm64_sonoma: "0eeabf84bee88e2b8079e8396fc2e8bd3f44edee15ee71fed914bed8f790f66b"
     sha256 cellar: :any, arm64_sonoma: "97ba5dc8d0777cd5cb4b47cce7a60d4bb3b0271cc52ea7e258dc2579a4e8894f"
     sha256 cellar: :any, monterey: "1bf6c43127f1a76628011b2ec2034c34378fd06b349646a04dade0430e86011a"
   end

--- a/Formula/mavryk-signer.rb
+++ b/Formula/mavryk-signer.rb
@@ -26,6 +26,7 @@ class MavrykSigner < Formula
 
   bottle do
     root_url "https://github.com/mavryk-network/mavryk-packaging/releases/download/#{MavrykSigner.version}/"
+    sha256 cellar: :any, arm64_sonoma: "28847b6a5d1b33ea5c2ccee6517e3b23f3c3566b1652f7083249e5208ec2b571"
     sha256 cellar: :any, arm64_sonoma: "2a88e5415da1de339df79ff26b8892105fadcff4716d86270637e408ae8f6740"
     sha256 cellar: :any, monterey: "d09f93834335b4f48c022a8e40433fb3abb376a1ac50458e4efbaef261cf1e1e"
   end


### PR DESCRIPTION
Problem: we have built brew bottles for the new Mavkit release, but their hashes
aren't in the formulae yet.

Solution: added the hashes.
